### PR TITLE
Adding initial docs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,235 @@
+# Chrona Design Document
+
+## Overview
+
+For managers, understanding the real state of a project is often difficult. For executives overseeing multiple projects, it is even harder. Each team may use different tools and ways of managing work, and keeping track requires jumping between 10 or more services. This fragmentation makes it nearly impossible to get a clear, timely view of progress across the organization.
+
+**Chrona** provides a transparent layer that organizes and simplifies the information you need, when you need it. The goal is to deliver clear project updates and summaries to different parts of the organization without requiring people to jump between tools.
+
+## Core Concepts
+
+Chrona’s data model is structured around a few key entities:
+
+- **Users**: Represent the people interacting with the system.
+- **Memberships**: Represent the relationship between users and workspaces.
+- **Workspaces**: The top-level organizational unit.
+  - **Projects**: Groupings of related work inside a workspace.
+  - **Entries**: The core unit of information aggregated from external sources.
+    - **Comments**: Discussion and activity attached to an entry.
+- **ImportJobs**: Represent each request to bring external data into Chrona.
+- **ImportItems**: Individual entries or comments submitted as part of an import job.
+- **ImportErrors**: Capture validation or processing errors for failed import items.
+
+## Entity Relationships
+
+```mermaid
+erDiagram
+  USERS }o--o{ WORKSPACES : "membership"
+  WORKSPACES ||--o{ PROJECTS : "contains"
+  PROJECTS  ||--o{ ENTRIES  : "contains"
+  ENTRIES   ||--o{ COMMENTS : "has"
+
+  USERS     ||--o{ ENTRIES  : "author"
+  USERS     ||--o{ COMMENTS : "author"
+
+  USERS {
+    uuid id PK
+    string name
+    string email
+    datetime created_at
+    datetime updated_at
+  }
+
+  WORKSPACES {
+    uuid id PK
+    string name
+    datetime created_at
+    datetime updated_at
+  }
+
+  PROJECTS {
+    uuid id PK
+    uuid workspace_id FK
+    string name
+    string status
+    datetime created_at
+    datetime updated_at
+  }
+
+  ENTRIES {
+    uuid id PK
+    uuid project_id FK
+    uuid author_id FK
+    string source      // jira, github_issue, github_pr, etc.
+    string external_id // id in source system
+    string title
+    text body
+    string[] tags
+    string[] labels
+    jsonb metadata     // source-specific fields
+    datetime created_at
+    datetime updated_at
+  }
+
+  COMMENTS {
+    uuid id PK
+    uuid entry_id FK
+    uuid author_id FK
+    text body
+    jsonb metadata     // source-specific fields
+    datetime created_at
+    datetime updated_at
+  }
+  IMPORT_JOBS ||--o{ IMPORT_ITEMS : "has"
+  IMPORT_ITEMS ||--o{ IMPORT_ERRORS : "has"
+
+  IMPORT_JOBS {
+    uuid id PK
+    string source
+    uuid requested_by FK
+    string status // queued, processing, completed, partial, failed
+    int received_count
+    int success_count
+    int failure_count
+    jsonb options
+    datetime created_at
+    datetime started_at
+    datetime finished_at
+  }
+
+  IMPORT_ITEMS {
+    uuid id PK
+    uuid job_id FK
+    string kind // entry | comment
+    string source
+    string external_id
+    jsonb raw_payload
+    uuid created_entry_id FK // nullable
+    uuid created_comment_id FK // nullable
+    string status // pending, succeeded, failed
+    string error_code // nullable
+    string error_message // nullable
+    datetime created_at
+    datetime updated_at
+  }
+
+  IMPORT_ERRORS {
+    uuid id PK
+    uuid item_id FK
+    string code
+    string message
+    jsonb context
+    datetime created_at
+  }
+```
+
+### Entries
+
+Entries represent data coming from external systems like Jira tickets, GitHub issues, or GitHub pull requests. Each entry has a set of common attributes:
+
+- `id`
+- `title`
+- `body`
+- `source` (e.g., Jira, GitHub)
+- `author`
+- `tags`
+- `labels`
+- `created_at`
+- `updated_at`
+
+In addition to these shared fields, entries can include an `extra_fields` or `metadata` column. This allows the system to store source-specific information while maintaining a unified structure across all entries.
+
+### Comments
+
+Comments capture conversations and activity attached to an entry. Like entries, they contain common attributes (id, body, author, timestamps) along with a `metadata` field for source-specific details.
+
+### Idempotency
+
+Imports are idempotent by `(source, external_id)`. When `options.upsert=true`, existing entries and comments are updated in place; otherwise duplicates are skipped and reported as failed with `code=duplicate`.
+
+## Purpose
+
+## Data Intake (Imports)
+
+Chrona accepts external data through a queued import flow. This avoids blocking callers and allows heavy normalization to run asynchronously.
+
+### API
+
+**Create import**
+
+`POST /imports`
+
+Body accepts either a single entry or a collection with comments.
+
+```json
+{
+  "source": "github_issue",
+  "requested_by": "user-uuid",
+  "entries": [
+    {
+      "external_id": "org/repo#1234",
+      "title": "Fix pagination bug",
+      "body": "…",
+      "author": "octocat",
+      "tags": ["bug", "api"],
+      "labels": ["priority:high"],
+      "created_at": "2025-09-01T10:00:00Z",
+      "updated_at": "2025-09-02T12:00:00Z",
+      "comments": [
+        {"external_id": "c1", "body": "Repro attached", "author": "qa", "created_at": "2025-09-01T11:00:00Z"}
+      ],
+      "metadata": {"repo": "org/repo"}
+    }
+  ],
+  "options": {"upsert": true}
+}
+```
+
+**Response**
+
+`202 Accepted`
+
+```json
+{
+  "id": "impt_01HXYZ…",
+  "status": "queued"
+}
+```
+
+**Check status**
+
+`GET /imports/{id}` returns:
+
+```json
+{
+  "id": "impt_01HXYZ…",
+  "status": "processing", // queued | processing | completed | failed | partial
+  "counts": {"received": 10, "succeeded": 9, "failed": 1},
+  "errors": [
+    {"item_id": "impi_01…", "code": "validation_error", "message": "missing title"}
+  ],
+  "started_at": "2025-09-05T12:00:00Z",
+  "finished_at": null
+}
+```
+
+### Storage model
+
+We persist import jobs and each submitted item to provide traceability and retries.
+
+- **ImportJob**: one per request to `/imports`.
+- **ImportItem**: one per entry (and optionally per comment) inside a job.
+- **ImportError**: optional error rows for failed items.
+
+### States
+
+`queued → processing → completed | partial | failed`
+
+- **completed**: all items succeeded.
+- **failed**: all items failed.
+- **partial**: some items succeeded while others failed (mixed outcome).
+
+
+Retries are idempotent. Upserts are controlled by `options.upsert` and `external_id + source`.
+
+By unifying updates from multiple tools into entries and comments, Chrona makes it easier to see progress, discussions, and context in one place. This enables project summaries and updates to be shared across the organization without requiring deep knowledge of each individual system.


### PR DESCRIPTION
# Introduce: Chrona Design Document (Initial Draft)

**Status:** Proposal → Living doc  
**Scope:** High-level architecture, data model, import flow  
**Non-goals:** Detailed API stability guarantees, perf targets, migrations

## Why
Managers and executives need a unified, low-friction view of project state across tools. This doc defines Chrona’s core entities, relationships, and import pipeline to enable consistent summaries and updates.

## What’s in this PR
- `docs/design.md` with:
  - Core concepts: Users, Memberships, Workspaces, Projects, Entries, Comments
  - Import model: ImportJobs, ImportItems, ImportErrors
  - Idempotency and upsert semantics
  - States: queued → processing → completed | partial | failed
  - Mermaid ERD
- No production code changes

## Review focus
- Are the entities and relationships sufficient for first milestones?
- Are idempotency and upsert rules clear and safe?
- Any missing fields or constraints for Entries/Comments and Import* tables?
- Gaps that would block early integrations (GitHub, Jira)?

## Known open questions / follow-ups
- Validation rules and error taxonomy completeness
- API surface for `/imports` options beyond `upsert`
- AuthN/Z model for workspaces and memberships
- Migration strategy and indexing for import tables

## How this doc will evolve
- Breaking conceptual changes require a separate PR.
- Small clarifications and diagrams can be updated directly with brief notes in the log.

## Acceptance checklist
- [ ] Major concepts accurate and minimal
- [ ] Risks and unknowns captured in “open questions”
- [ ] Clear next steps/issues filed for follow-ups